### PR TITLE
Rename FUV to PUV

### DIFF
--- a/GLOBAL_VARS.py
+++ b/GLOBAL_VARS.py
@@ -52,8 +52,8 @@ POINTS: List[Coordinate] = []  # Array of the coordinates of data points
 NUMPOINTS: int = 0  # Number of data points
 LCM: CMatrix = []   # Logical Connector Matrix
 PUM: BMatrix = []   # Preliminary Unlocking Matrix
-CMV: Vector = []   # Conditions Met Vector
-FUV: Vector = []    # Final Unlocking Vector
+CMV: Vector = []    # Conditions Met Vector
+PUV: Vector = []    # Preliminary Unlocking Vector
 LAUNCH: bool = False          # Decision: Launch or No Launch
 
 def test_values():
@@ -67,4 +67,4 @@ def test_values():
         print(len(LCM[i]))
         print(LCM[i])
 
-    print("FUV ({}): {}".format(len(FUV), FUV))
+    print("PUV ({}): {}".format(len(PUV), PUV))

--- a/decide_io.py
+++ b/decide_io.py
@@ -101,9 +101,9 @@ def parse_input(queue : deque):
     for i in range(gv.LIC_COUNT):
 
         if re.fullmatch("TRUE", row[i]):
-            gv.FUV.append(True)
+            gv.PUV.append(True)
         elif re.fullmatch("FALSE", row[i]):
-            gv.FUV.append(False)
+            gv.PUV.append(False)
         else:
             raise ValueError
 


### PR DESCRIPTION
Since the vector read from input is the content to the PUV, and that is what we want to store, the vector in GLOBAL_VARS should be named PUV. We recon we wont need a global FUV vector since the results of that vector is calulated in the last step and only used shortly.

Closes #69